### PR TITLE
Using a topline to provide flexibility of topline to match 

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,3 +3,4 @@ Iteround is written and maintained by Calvin DeBoer.
 Authors
 ```````````````````````
 - Calvin DeBoer <cgdeboer@gmail.com> `@cgdeboer <https://github.com/cgdeboer>`_
+- Manikandan Nagarajan <manikandan_nagarajan@ymail.com> `@M22an <https://github.com/M22an>`_

--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,12 @@ iterable (list, dict, set, numpy.array, generator): list(y) of numbers
 
 places (int): Places for rounding.
     Number of places each item in the set should be rounded to.
+	
+topline (float, optional): Topline to match
+	Useful in places where we want the total sum to match a different topline 
+	than the sum of iterable. This can useful in cases where original values 
+	are altered before passing into the saferound method, but the original sum
+	needs to be maintained.
 
 strategy (str, optional): The strategy used to clean up rounding errors
     'difference', 'largest', 'smallest'. Defaults to 'difference'

--- a/iteround/core.py
+++ b/iteround/core.py
@@ -6,7 +6,7 @@ LARGEST = 'largest'
 DIFFERENCE = 'difference'
 
 
-def saferound(iterable, places, strategy=DIFFERENCE, rounder=round):
+def saferound(iterable, places, topline=-1, strategy=DIFFERENCE, rounder=round):
     """Rounds an iterable of floats while retaining the original summed value.
 
     Function parameters should be documented in the ``Args`` section. The name
@@ -65,7 +65,7 @@ def saferound(iterable, places, strategy=DIFFERENCE, rounder=round):
 
     # calculate original sum, rounded,  then rounded local sum.
     local = [Number(i, value) for i, value in enumerate(values)]
-    orig_sum = _sumnum(local, places, rounder)
+    orig_sum = _sumnum(local, places, rounder) if topline == -1 else topline
     [n.round(places, rounder) for n in local]
     local_sum = _sumnum(local, places, rounder)
 

--- a/iteround/core.py
+++ b/iteround/core.py
@@ -71,7 +71,7 @@ def saferound(iterable, places, strategy=DIFFERENCE, rounder=round, topline=None
 
     # calculate original sum, rounded,  then rounded local sum.
     local = [Number(i, value) for i, value in enumerate(values)]
-    orig_sum = _sumnum(local, places, rounder) if topline is None else rounder(topline)
+    orig_sum = _sumnum(local, places, rounder) if topline is None else rounder(topline, places)
     [n.round(places, rounder) for n in local]
     local_sum = _sumnum(local, places, rounder)
 

--- a/iteround/core.py
+++ b/iteround/core.py
@@ -6,7 +6,7 @@ LARGEST = 'largest'
 DIFFERENCE = 'difference'
 
 
-def saferound(iterable, places, topline=-1, strategy=DIFFERENCE, rounder=round):
+def saferound(iterable, places, strategy=DIFFERENCE, rounder=round, topline=None):
     """Rounds an iterable of floats while retaining the original summed value.
 
     Function parameters should be documented in the ``Args`` section. The name
@@ -19,6 +19,12 @@ def saferound(iterable, places, topline=-1, strategy=DIFFERENCE, rounder=round):
 
         places (int): Places for rounding.
             Number of places each item in the set should be rounded to.
+            
+        topline (float, optional): Topline to match
+            Useful in places where we want the total sum to match a different topline 
+            than the sum of iterable. This can useful in cases where original values 
+            are altered before passing into the saferound method, but the original sum
+            needs to be maintained.
 
         strategy (str, optional): The strategy used to clean up rounding errors
             'difference', 'largest', 'smallest'. Defaults to 'difference'
@@ -65,7 +71,7 @@ def saferound(iterable, places, topline=-1, strategy=DIFFERENCE, rounder=round):
 
     # calculate original sum, rounded,  then rounded local sum.
     local = [Number(i, value) for i, value in enumerate(values)]
-    orig_sum = _sumnum(local, places, rounder) if topline == -1 else topline
+    orig_sum = _sumnum(local, places, rounder) if topline is None else rounder(topline)
     [n.round(places, rounder) for n in local]
     local_sum = _sumnum(local, places, rounder)
 

--- a/tests/test_saferound.py
+++ b/tests/test_saferound.py
@@ -2,7 +2,6 @@ import unittest
 import iteround
 from collections import OrderedDict
 
-
 class TestSafeRoundMethods(unittest.TestCase):
 
     def setUp(self):
@@ -78,6 +77,19 @@ class TestSafeRoundMethods(unittest.TestCase):
     def test_over_with_sum(self):
         out = [0.0, 0.0, 0.0, 10.0, 10.0, 10.0]
         self.assertListEqual(iteround.saferound(self.in_list, -1), out)
+
+    def test_topline(self):
+        out = [4.0, 3.0, 3.0, 7.0, 5.0, 7.0]
+        topline = 29
+        actual_out = iteround.saferound(self.in_list, 0, topline=topline)
+        actual_topline = sum(actual_out)
+        self.assertListEqual(actual_out, out)
+        self.assertEqual(topline, actual_topline)
+
+    def test_topline_sum(self):
+        self.assertEqual(sum(iteround.saferound(self.in_list, 0, topline=28)), 28)
+        self.assertEqual(sum(iteround.saferound(self.in_list, 0, topline=29)), 29)
+        self.assertEqual(sum(iteround.saferound(self.in_list, 0, topline=30)), 30)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
There are some cases we have where we want to ensure that the overall sum remains the same not on the sum of input, but based on another topline. 

I have made the code changes, by default the existing logic of retaining the sum of inputs is maintained, **topline** is added as an optional parameter.