### PR TITLE
Safely allowing integers

### DIFF
--- a/iteround/core.py
+++ b/iteround/core.py
@@ -63,7 +63,7 @@ def saferound(iterable, places, strategy=DIFFERENCE, rounder=round, topline=None
     values = iterable
     if (isinstance(iterable, dict) or isinstance(iterable, OrderedDict)):
         keys, values = zip(*iterable.items())
-    assert all([isinstance(x, float) for x in values])
+    assert all([isinstance(x, (float, int)) for x in values])
 
     # define a sorting method for rounded differences
     sorter = _sort_by_diff if strategy == DIFFERENCE else _sort_by_value

--- a/tests/test_saferound.py
+++ b/tests/test_saferound.py
@@ -97,6 +97,10 @@ class TestSafeRoundMethods(unittest.TestCase):
         actual_out = iteround.saferound([], 0, topline=topline)
         self.assertListEqual(actual_out, out)
 
+    def test_integers(self):
+        out = [4, 3.24, 3.23, 6.45, 5.35, 7.34]
+        self.assertListEqual(iteround.saferound(self.in_list, 2), out)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
If you input a list to round that has an integer number, it should not throw. Having hard requirement of list being floats is an over-validation and should allow integers as well.